### PR TITLE
Replace invalid characters in artifact name with underscore

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ import {opendir} from 'node:fs/promises';
 import {join} from 'node:path';
 
 try {
-  const name = core.getInput('name');
+  // replace invalid characters in artifact name with underscore ('_')
+  // see https://github.com/actions/toolkit/blob/ef77c9d60bdb03700d7758b0d04b88446e72a896/packages/artifact/src/internal/upload/path-and-artifact-name-validation.ts
+  const name = core.getInput('name').replace(/[":<>|*?\r\n\\/]/g, '_');
   const options = {
     retentionDays: parseInt(core.getInput('retention-days'))
   };


### PR DESCRIPTION
This action may fail if its `name` input contains invalid characters set by `@actions/artifact`.

For example in [`main.yaml`](https://github.com/latex3/latex2e/blob/05e3cb969ad621d30b9b3354317d9894eaeb7c72/.github/workflows/main.yaml) workflow file in latex3/latex2e repo, the value passed to `name` consists of `matrix.module` of current job, which may contain `/`, one of the invalid characters.
```yaml
      # Now we create the artifacts for the logs of failed tests
      - name: Archive failed test output
        if: ${{ always() }}
        uses: zauguin/l3build-failure-artifacts@v1
        with:
          # example names:
          # - "testfiles-base-build-pdflatex"
          # - "testfiles-base-config-1run"
          # - "testfiles-required/amsmath"
          name: testfiles-${{ matrix.module }}${{ matrix.config && format('-{0}', matrix.config)  || ''}}${{ matrix.engine && format('-{0}', matrix.engine) || ''}}
          # Decide how long to keep the test output artifact:
          retention-days: 3
```

An example failed workflow run https://github.com/muzimuzhi/latex2e/actions/runs/8396985969/job/22999514640
```
Error: Artifact name is not valid: testfiles-required/latex-lab-config-float. Contains the following character:  Forward slash /
          
Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, Carriage return \r, Line feed \n, Backslash \, Forward slash /
```

This PR replaces all invalid characters with underscores (`_`).